### PR TITLE
Dev audio rework

### DIFF
--- a/src/cadmium.cpp
+++ b/src/cadmium.cpp
@@ -519,7 +519,7 @@ public:
     #ifdef RESIZABLE_GUI
         SetConfigFlags(FLAG_WINDOW_RESIZABLE | FLAG_COCOA_GRAPHICS_SWITCHING);
     #else
-        SetConfigFlags(FLAG_COCOA_GRAPHICS_SWITCHING/*|FLAG_VSYNC_HINT*/);
+        //SetConfigFlags(FLAG_COCOA_GRAPHICS_SWITCHING/*|FLAG_VSYNC_HINT*/);
     #endif
 #else
     #ifdef RESIZABLE_GUI
@@ -708,9 +708,14 @@ public:
         std::scoped_lock lock(_audioMutex);
         _audioCallbackAvgFrames = _audioCallbackAvgFrames ? (_audioCallbackAvgFrames + frames)/2 : frames;
         if(_chipEmu) {
-            if(_audioBuffer.dataAvailable() > frames && _chipEmu->getExecMode() == emu::GenericCpu::eRUNNING) {
+            if(_chipEmu->getExecMode() == emu::GenericCpu::eRUNNING) {
                 auto len = _audioBuffer.read(samples, frames);
                 frames -= len;
+                samples += len;
+                if(frames) {
+                    _chipEmu->renderAudio(samples, frames, 44100);
+                    frames = 0;
+                }
             }
         }
         while(frames--) {
@@ -1517,7 +1522,7 @@ public:
                             SetRowHeight(20);
                             if(!_chipEmu->isGenericEmulation() || _options.behaviorBase == emu::Chip8EmulatorOptions::eCHIP8TE)
                                 GuiDisable();
-                            Spinner("Instructions per frame", &_options.instructionsPerFrame, 0, 500000);
+                            Spinner("Instructions per frame", &_options.instructionsPerFrame, 0, 1000000);
                             Spinner("Frame rate", &_options.frameRate, 10, 120);
                             if(!_chipEmu->isGenericEmulation() || _options.behaviorBase == emu::Chip8EmulatorOptions::eCHIP8TE)
                                 GuiEnable();

--- a/src/cadmium.cpp
+++ b/src/cadmium.cpp
@@ -514,7 +514,6 @@ public:
         , _screenHeight(MIN_SCREEN_HEIGHT)
     {
         SetTraceLogCallback(LogHandler);
-
 #ifdef WITH_FLAG_COCOA_GRAPHICS_SWITCHING
     #ifdef RESIZABLE_GUI
         SetConfigFlags(FLAG_WINDOW_RESIZABLE | FLAG_COCOA_GRAPHICS_SWITCHING);
@@ -632,7 +631,12 @@ public:
 */
 #ifdef PLATFORM_WEB
         JsClipboard_AddJsHook();
+#else
+        _volume = _volumeSlider = _cfg.volume;
 #endif
+        if(_volume > 1.0f)
+            _volume = _volumeSlider = 1.0f;
+        SetMasterVolume(_volume);
     }
 
     ~Cadmium() override
@@ -1037,7 +1041,6 @@ public:
                 _chipEmu->tick(getInstrPerFrame());
                 g_soundTimer.store(_chipEmu->soundTimer());
             }
-            pushAudio(44100 / 60);
         }
         else {
             static int cntx = 0;
@@ -1050,7 +1053,6 @@ public:
             else {
                 excessTime = 0;
             }
-            pushAudio(deltaT);
         }
 
         if(_chipEmu->needsScreenUpdate())
@@ -1185,6 +1187,7 @@ public:
         static uint32_t* selectedColor = nullptr;
         static std::string colorText;
         static uint32_t previousColor{};
+        static std::chrono::steady_clock::time_point volumeClick{};
 
 #ifdef RESIZABLE_GUI
         auto screenScale = std::min(std::clamp(int(GetScreenWidth() / _screenWidth), 1, 8), std::clamp(int(GetScreenHeight() / _screenHeight), 1, 8));
@@ -1414,7 +1417,7 @@ public:
                     }
                 }
                 SetTooltip("RESTART");
-                int buttonsRight = 6;
+                int buttonsRight = 7;
 #ifdef WITH_EDITOR
                 ++buttonsRight;
 #endif
@@ -1450,6 +1453,9 @@ public:
                 if (iconButton(ICON_GEAR, _mainView == eSETTINGS))
                     _mainView = eSETTINGS;
                 SetTooltip("SETTINGS");
+                if (iconButton(ICON_AUDIO, false))
+                    volumeClick = std::chrono::steady_clock::now();
+                SetTooltip("VOLUME");
 
                 static Vector2 versionSize = MeasureTextEx(GuiGetFont(), "v" CADMIUM_VERSION, 8, 0);
                 DrawTextEx(GuiGetFont(), "v" CADMIUM_VERSION, {spacePos.x + (spaceWidth - versionSize.x) / 2, spacePos.y + 6}, 8, 0, WHITE);
@@ -1526,7 +1532,7 @@ public:
                             Spinner("Frame rate", &_options.frameRate, 10, 120);
                             if(!_chipEmu->isGenericEmulation() || _options.behaviorBase == emu::Chip8EmulatorOptions::eCHIP8TE)
                                 GuiEnable();
-                            if (!_options.instructionsPerFrame) {
+                            if (true/*!_options.instructionsPerFrame*/) {
                                 static int _fb1{1};
                                 GuiDisable();
                                 Spinner("Frame boost", &_fb1, 1, 100000);
@@ -1852,6 +1858,27 @@ public:
                 }
                 EndColumns();
                 EndWindowBox();
+            }
+            if(IsKeyDown(KEY_ESCAPE))
+                volumeClick = std::chrono::steady_clock::time_point{};
+            if(volumeClick != std::chrono::steady_clock::time_point{}) {
+                if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - volumeClick).count() < 2) {
+                    Rectangle bounds{430.0, 21.0f, 80.0f, 14.0f};
+                    DrawRectangleRec({bounds.x-56, bounds.y-2, bounds.width+58, bounds.height+4}, {0,0,0,128});
+                    GuiSliderBar(bounds, "Volume: ", "", &_volumeSlider, 0.0001f, 1.0f);
+                    if (_volumeSlider != _volume)
+                        SetMasterVolume(_volumeSlider);
+                    if (CheckCollisionPointRec(GetMousePosition(), bounds)) {
+                        volumeClick = std::chrono::steady_clock::now();
+                    }
+                }
+                else {
+                    if (_volumeSlider != _volume) {
+                        _volume = _volumeSlider;
+                        _cfg.volume = _volume;
+                        saveConfig();
+                    }
+                }
             }
             EndGui();
         }
@@ -2269,6 +2296,8 @@ private:
     int _screenHeight{};
     RenderTexture _renderTexture{};
     AudioStream _audioStream{};
+    float _volumeSlider{0.5f};
+    float _volume{0.5f};
     SMA<60,uint64_t> _ipfAverage;
     SMA<120,uint32_t> _frameTimeAverage_us;
     SMA<120,int> _frameDelta;

--- a/src/chip8emuhostex.cpp
+++ b/src/chip8emuhostex.cpp
@@ -125,7 +125,7 @@ bool Chip8EmuHostEx::loadRom(const char* filename, bool andRun)
         _editor.setText("");
         _editor.setFilename("");
 #endif
-        auto fileData = loadFile(filename);
+        auto fileData = loadFile(filename, Librarian::MAX_ROM_SIZE);
         return loadBinary(filename, fileData.data(), fileData.size(), andRun);
         //memory[0x1FF] = 3;
     }

--- a/src/chip8emuhostex.hpp
+++ b/src/chip8emuhostex.hpp
@@ -89,6 +89,7 @@ public:
     bool isKeyDown(uint8_t key) override { return false; }
     const std::array<bool,16>& getKeyStates() const override { static const std::array<bool,16> keys{}; return keys; }
     void updateScreen() override {}
+    void vblank() override {}
     void updatePalette(const std::array<uint8_t,16>& palette) override {}
     void updatePalette(const std::vector<uint32_t>& palette, size_t offset) override {}
 };

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -30,6 +30,7 @@
 
 void to_json(nlohmann::json& j, const CadmiumConfiguration& cc) {
     j = nlohmann::json{
+        {"volume", cc.volume},
         {"workingDirectory", cc.workingDirectory},
         {"databaseDirectory", cc.databaseDirectory},
         {"emuOptions", cc.emuOptions},
@@ -40,6 +41,7 @@ void to_json(nlohmann::json& j, const CadmiumConfiguration& cc) {
 void from_json(const nlohmann::json& j, CadmiumConfiguration& cc) {
     j.at("workingDirectory").get_to(cc.workingDirectory);
     cc.databaseDirectory = j.value("databaseDirectory", "");
+    cc.volume = j.value("volume", 0.5f);
     try {
         j.at("emuOptions").get_to(cc.emuOptions);
     }

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -33,6 +33,7 @@
 
 struct CadmiumConfiguration
 {
+    float volume;
     std::string workingDirectory;
     std::string databaseDirectory;
     emu::Chip8EmulatorOptions emuOptions;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -183,6 +183,8 @@ protected:
     int _cursorY{0};
     uint32_t _visibleLines{0};
     uint32_t _visibleCols{0};
+    int _lineNumberWidth{6*COLUMN_WIDTH};
+    uint32_t _lineNumberCols{6};
     uint32_t _selectionStart{0};
     uint32_t _selectionEnd{0};
     uint32_t _editId{0};

--- a/src/emulation/chip8cores.cpp
+++ b/src/emulation/chip8cores.cpp
@@ -1387,7 +1387,7 @@ void Chip8EmulatorFP::opFx85(uint16_t opcode)
 void Chip8EmulatorFP::opFxF8_c8x(uint16_t opcode)
 {
     uint8_t val = _rV[(opcode >> 8) & 0xF];
-    _vp595Frequency = val ? val : 0x80;
+    _vp595Frequency = 80;//val ? val : 0x80;
 }
 
 void Chip8EmulatorFP::opFxFB_c8x(uint16_t opcode)

--- a/src/emulation/chip8cores.cpp
+++ b/src/emulation/chip8cores.cpp
@@ -377,12 +377,12 @@ uint8_t Chip8EmulatorFP::getNextMCSample()
             if(_sampleLoop)
                 pos -= _sampleLength;
             else
-                pos = _sampleLength = 0, val = 127;
+                pos = _sampleLength = 0, val = 128;
         }
         _mcSamplePos.store(pos);
         return val;
     }
-    return 127;
+    return 128;
 }
 
 void Chip8EmulatorFP::on(uint16_t mask, uint16_t opcode, OpcodeHandler handler)
@@ -684,8 +684,6 @@ void Chip8EmulatorFP::op02nn(uint16_t opcode)
         auto g = _memory[address++ & ADDRESS_MASK];
         auto b = _memory[address++ & ADDRESS_MASK];
         _mcPalette[i + 1] = be32((r << 24) | (g << 16) | (b << 8) | a);
-        if(i == 250)
-            std::cout << "i: " << i << " - " << std::endl;
         cols.push_back(be32((r << 24) | (g << 16) | (b << 8) | a));
     }
     _host.updatePalette(cols, 1);
@@ -1397,7 +1395,12 @@ void Chip8EmulatorFP::opFxFB_c8x(uint16_t opcode)
 
 void Chip8EmulatorFP::renderAudio(int16_t* samples, size_t frames, int sampleFrequency)
 {
-    if(_rST) {
+    if(_isMegaChipMode && _sampleLength) {
+        while(frames--) {
+            *samples++ = ((int16_t)getNextMCSample() - 128) * 256;
+        }
+    }
+    else if(_rST) {
         if (_options.optXOChipSound) {
             auto step = 4000 * std::pow(2.0f, (float(_xoPitch) - 64) / 48.0f) / 128 / sampleFrequency;
             for (int i = 0; i < frames; ++i) {
@@ -1405,12 +1408,6 @@ void Chip8EmulatorFP::renderAudio(int16_t* samples, size_t frames, int sampleFre
                 *samples++ = _xoAudioPattern[pos >> 3] & (1 << (7 - (pos & 7))) ? 16384 : -16384;
                 _wavePhase = std::fmod(_wavePhase + step, 1.0f);
             }
-        }
-        else if(_isMegaChipMode) {
-            while(frames--) {
-                *samples++ = ((int16_t)getNextMCSample() - 128) * 256;
-            }
-            return;
         }
         else {
             auto audioFrequency = _options.behaviorBase == Chip8EmulatorOptions::eCHIP8X ? 27535.0f / ((unsigned)_vp595Frequency + 1) : 1400.0f;
@@ -1423,6 +1420,7 @@ void Chip8EmulatorFP::renderAudio(int16_t* samples, size_t frames, int sampleFre
     }
     else {
         // Default is silence
+        _wavePhase = 0;
         IChip8Emulator::renderAudio(samples, frames, sampleFrequency);
     }
 }

--- a/src/emulation/chip8cores.cpp
+++ b/src/emulation/chip8cores.cpp
@@ -1229,9 +1229,12 @@ void Chip8EmulatorFP::opF000(uint16_t opcode)
 
 void Chip8EmulatorFP::opF002(uint16_t opcode)
 {
+    uint8_t anyBit = 0;
     for(int i = 0; i < 16; ++i) {
         _xoAudioPattern[i] = _memory[(_rI + i) & ADDRESS_MASK];
+        anyBit |= _xoAudioPattern[i];
     }
+    _xoSilencePattern = anyBit != 0;
 }
 
 void Chip8EmulatorFP::opFx01(uint16_t opcode)

--- a/src/emulation/chip8cores.hpp
+++ b/src/emulation/chip8cores.hpp
@@ -798,10 +798,13 @@ public:
             return (bool)collision;
     }
 
-    float getAudioFrequency() const override
+    /*float getAudioFrequency() const override
     {
         return _options.behaviorBase == Chip8EmulatorOptions::eCHIP8X ? 27535.0f / ((unsigned)_vp595Frequency + 1) : 1400.0f;
-    }
+    }*/
+
+    void renderAudio(int16_t* samples, size_t frames, int sampleFrequency) override;
+
 private:
     inline uint16_t readWord(uint32_t addr) const
     {
@@ -825,6 +828,7 @@ public:
     bool isKeyDown(uint8_t key) override { return false; }
     const std::array<bool,16>& getKeyStates() const override { static const std::array<bool,16> keys{}; return keys; }
     void updateScreen() override {}
+    void vblank() override {}
     void updatePalette(const std::array<uint8_t,16>& palette) override {}
     void updatePalette(const std::vector<uint32_t>& palette, size_t offset) override {}
     Chip8EmulatorOptions options;

--- a/src/emulation/chip8dream.cpp
+++ b/src/emulation/chip8dream.cpp
@@ -416,7 +416,7 @@ uint8_t Chip8Dream::soundTimer() const
     return (_impl->_pia.portB() & 64) ? _state.st : 0;
 }
 
-float Chip8Dream::getAudioPhase() const
+/*float Chip8Dream::getAudioPhase() const
 {
     return _impl->_wavePhase;
 }
@@ -424,6 +424,21 @@ float Chip8Dream::getAudioPhase() const
 void Chip8Dream::setAudioPhase(float phase)
 {
     _impl->_wavePhase = phase;
+}*/
+
+void Chip8Dream::renderAudio(int16_t* samples, size_t frames, int sampleFrequency)
+{
+    if(_state.st) {
+        const float step = 1000.0f / sampleFrequency;
+        for (int i = 0; i < frames; ++i) {
+            *samples++ = (_impl->_wavePhase > 0.5f) ? 16384 : -16384;
+            _impl->_wavePhase = std::fmod(_impl->_wavePhase + step, 1.0f);
+        }
+    }
+    else {
+        // Default is silence
+        IChip8Emulator::renderAudio(samples, frames, sampleFrequency);
+    }
 }
 
 uint16_t Chip8Dream::getCurrentScreenWidth() const

--- a/src/emulation/chip8dream.cpp
+++ b/src/emulation/chip8dream.cpp
@@ -280,6 +280,7 @@ int Chip8Dream::executeVDG()
         _impl->_pia.pinCB1(true);
         _impl->_pia.pinCB1(false);
         _impl->_keyMatrix.updateKeys(_host.getKeyStates());
+        _host.vblank();
     }
     lastFC = fc;
     return fc;

--- a/src/emulation/chip8dream.hpp
+++ b/src/emulation/chip8dream.hpp
@@ -61,8 +61,9 @@ public:
     const VideoType* getScreen() const override;
 
     uint8_t soundTimer() const override;
-    float getAudioPhase() const override;
-    void setAudioPhase(float phase) override;
+    //float getAudioPhase() const override;
+    //void setAudioPhase(float phase) override;
+    void renderAudio(int16_t* samples, size_t frames, int sampleFrequency) override;
 
     // M6800-Bus
     uint8_t readByte(uint16_t addr) const override;

--- a/src/emulation/chip8emulatorbase.cpp
+++ b/src/emulation/chip8emulatorbase.cpp
@@ -333,6 +333,7 @@ void Chip8EmulatorBase::reset()
         std::memcpy(_memory.data() + 16*5, bigFont, bigSize);
     std::memcpy(_xxoPalette.data(), defaultPalette, 16);
     std::memset(_xoAudioPattern.data(), 0, 16);
+    _xoSilencePattern = true;
     _xoPitch = 64;
     _planes = 0xff;
     clearScreen();

--- a/src/emulation/chip8emulatorbase.cpp
+++ b/src/emulation/chip8emulatorbase.cpp
@@ -399,7 +399,7 @@ void Chip8EmulatorBase::tick(int instructionsPerFrame)
         do {
             executeInstructions(487);
         }
-        while(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() < 14);
+        while(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() < 12);
     }
     else {
         executeInstructions(instructionsPerFrame);

--- a/src/emulation/chip8emulatorbase.hpp
+++ b/src/emulation/chip8emulatorbase.hpp
@@ -91,6 +91,7 @@ public:
             _screenRGBA = other->_screenRGBA;
             _xoAudioPattern = other->_xoAudioPattern;
             _xoPitch.store(other->_xoPitch);
+            _xoSilencePattern = other->_xoSilencePattern;
             _sampleStep.store(other->_sampleStep);
             _sampleStart.store(other->_sampleStart);
             _sampleLength.store(other->_sampleLength);
@@ -250,6 +251,7 @@ public:
                 _host.updateScreen();
                 _screenNeedsUpdate = false;
             }
+            _host.vblank();
         }
     }
 
@@ -305,6 +307,7 @@ protected:
     VideoScreen<uint8_t, MAX_SCREEN_WIDTH, MAX_SCREEN_HEIGHT> _screen;
     VideoScreen<uint32_t, MAX_SCREEN_WIDTH, MAX_SCREEN_HEIGHT> _screenRGBA{};
     std::array<uint8_t,16> _xoAudioPattern{};
+    bool _xoSilencePattern{true};
     std::atomic_uint8_t _xoPitch{};
     std::atomic<float> _sampleStep{0};
     std::atomic_uint32_t _sampleStart{0};

--- a/src/emulation/chip8emulatorbase.hpp
+++ b/src/emulation/chip8emulatorbase.hpp
@@ -71,8 +71,8 @@ public:
             std::memcpy(_stack.data(), iother->getStackElements(), sizeof(uint16_t) * iother->stackSize());
             _rSP = iother->getSP();
             _rDT = iother->delayTimer();
-            _rST.store(iother->soundTimer());
-            _wavePhase.store(iother->getAudioPhase());
+            _rST = iother->soundTimer();
+            _wavePhase =  0; //iother->getAudioPhase();
             for (int i = 0; i < 16; ++i) {
                 _rV[i] = iother->getV(i);
             }
@@ -246,8 +246,10 @@ public:
                 --_rST;
             if (!_rST)
                 _wavePhase = 0;
-            if(_screenNeedsUpdate)
+            if(_screenNeedsUpdate) {
                 _host.updateScreen();
+                _screenNeedsUpdate = false;
+            }
         }
     }
 
@@ -264,8 +266,8 @@ public:
     const VideoRGBAType* getScreenRGBA() const override { return _isMegaChipMode ? &_screenRGBA : nullptr; }
     void setPalette(std::array<uint32_t,256>& palette) override { _screen.setPalette(palette); }
 
-    float getAudioPhase() const override { return _wavePhase; }
-    void setAudioPhase(float phase) override { _wavePhase = phase; }
+    //float getAudioPhase() const override { return _wavePhase; }
+    //void setAudioPhase(float phase) override { _wavePhase = phase; }
     const uint8_t* getXOAudioPattern() const override { return _xoAudioPattern.data(); }
     uint8_t getXOPitch() const override { return _xoPitch; }
 
@@ -298,8 +300,8 @@ protected:
     std::array<uint16_t,16> _stack{};
     uint8_t _rSP{};
     uint8_t _rDT{};
-    std::atomic_uint8_t _rST{};
-    std::atomic<float> _wavePhase{0};
+    uint8_t _rST{};
+    float _wavePhase{0};
     VideoScreen<uint8_t, MAX_SCREEN_WIDTH, MAX_SCREEN_HEIGHT> _screen;
     VideoScreen<uint32_t, MAX_SCREEN_WIDTH, MAX_SCREEN_HEIGHT> _screenRGBA{};
     std::array<uint8_t,16> _xoAudioPattern{};

--- a/src/emulation/chip8emulatorhost.hpp
+++ b/src/emulation/chip8emulatorhost.hpp
@@ -42,6 +42,7 @@ public:
     virtual bool isKeyUp(uint8_t key) { return !isKeyDown(key); }
     virtual const std::array<bool,16>& getKeyStates() const = 0;
     virtual void updateScreen() = 0;
+    virtual void vblank() = 0;
     virtual void updatePalette(const std::array<uint8_t, 16>& palette) = 0;
     virtual void updatePalette(const std::vector<uint32_t>& palette, size_t offset) = 0;
     virtual void preClear() {}

--- a/src/emulation/chip8strict.hpp
+++ b/src/emulation/chip8strict.hpp
@@ -461,6 +461,21 @@ public:
         _screenNeedsUpdate = true;
         return collision;
     }
+
+    void renderAudio(int16_t* samples, size_t frames, int sampleFrequency) override
+    {
+        if(_rST) {
+            const float step = 1000.0f / 44100;
+            for (int i = 0; i < frames; ++i) {
+                *samples++ = (_wavePhase > 0.5f) ? 16384 : -16384;
+                _wavePhase = std::fmod(_wavePhase + step, 1.0f);
+            }
+        }
+        else {
+            // Default is silence
+            IChip8Emulator::renderAudio(samples, frames, sampleFrequency);
+        }
+    }
 protected:
     void wait(int instructionCycles = 0)
     {
@@ -500,8 +515,9 @@ protected:
             --_rST;
         if (!_rST)
             _wavePhase = 0;
-        if(_screenNeedsUpdate)
+        if(_screenNeedsUpdate) {
             _host.updateScreen();
+        }
     }
     inline void addCycles(emu::cycles_t cycles)
     {

--- a/src/emulation/chip8strict.hpp
+++ b/src/emulation/chip8strict.hpp
@@ -518,6 +518,7 @@ protected:
         if(_screenNeedsUpdate) {
             _host.updateScreen();
         }
+        _host.vblank();
     }
     inline void addCycles(emu::cycles_t cycles)
     {

--- a/src/emulation/chip8vip.cpp
+++ b/src/emulation/chip8vip.cpp
@@ -442,7 +442,9 @@ bool Chip8VIP::executeCdp1802()
 {
     static int lastFC = 0;
     static int endlessLoops = 0;
-    auto fc = _impl->_video.executeStep();
+    auto [fc,vsync] = _impl->_video.executeStep();
+    if(vsync)
+        _host.vblank();
     if(_options.optTraceLog  && _impl->_cpu.getCpuState() != Cdp1802::eIDLE)
         Logger::log(Logger::eBACKEND_EMU, _impl->_cpu.getCycles(), {_frames, fc}, fmt::format("{:24} ; {}", _impl->_cpu.disassembleInstructionWithBytes(-1, nullptr), _impl->_cpu.dumpStateLine()).c_str());
     if(_impl->_cpu.PC() == Private::FETCH_LOOP_ENTRY) {

--- a/src/emulation/chip8vip.cpp
+++ b/src/emulation/chip8vip.cpp
@@ -613,12 +613,12 @@ void Chip8VIP::renderAudio(int16_t* samples, size_t frames, int sampleFrequency)
         const float step = audioFrequency / sampleFrequency;
         for (int i = 0; i < frames; ++i) {
             *samples++ = (_impl->_wavePhase > 0.5f) ? 16384 : -16384;
-            _impl->_wavePhase += _impl->_wavePhase + step;
-            while (_impl->_wavePhase >= 1.0) _impl->_wavePhase -= 1.0;
+            _impl->_wavePhase = std::fmod(_impl->_wavePhase + step, 1.0f);
         }
     }
     else {
         // Default is silence
+        _impl->_wavePhase = 0;
         IChip8Emulator::renderAudio(samples, frames, sampleFrequency);
     }
 }

--- a/src/emulation/chip8vip.hpp
+++ b/src/emulation/chip8vip.hpp
@@ -68,9 +68,10 @@ public:
 
     bool isDisplayEnabled() const override;
 
-    float getAudioPhase() const override;
-    void setAudioPhase(float phase) override;
-    float getAudioFrequency() const override;
+    //float getAudioPhase() const override;
+    //void setAudioPhase(float phase) override;
+    //float getAudioFrequency() const override;
+    void renderAudio(int16_t* samples, size_t frames, int sampleFrequency) override;
 
     // CDP1802-Bus
     uint8_t readByte(uint16_t addr) const override;

--- a/src/emulation/hardware/cdp186x.cpp
+++ b/src/emulation/hardware/cdp186x.cpp
@@ -89,7 +89,7 @@ const Cdp186x::VideoType& Cdp186x::getScreen() const
     return _screen;
 }
 
-int Cdp186x::executeStep()
+std::pair<int,bool> Cdp186x::executeStep()
 {
     auto fc = (_cpu.getCycles() >> 3) % 3668;
     bool vsync = false;
@@ -106,7 +106,7 @@ int Cdp186x::executeStep()
             Logger::log(Logger::eBACKEND_EMU, _cpu.getCycles(), {_frameCounter, _frameCycle}, fmt::format("{:24} ; {}", "--- HSYNC ---", _cpu.dumpStateLine()).c_str());
     }
     if(_frameCycle > VIDEO_FIRST_INVISIBLE_LINE * 14 || _frameCycle < (VIDEO_FIRST_VISIBLE_LINE - 2) * 14)
-        return _frameCycle;
+        return {_frameCycle,vsync};
     if(_frameCycle < VIDEO_FIRST_VISIBLE_LINE * 14 && _frameCycle >= (VIDEO_FIRST_VISIBLE_LINE - 2) * 14 + 2 && _cpu.getIE()) {
         _displayEnabledLatch = _displayEnabled;
         if(_displayEnabled) {
@@ -138,7 +138,7 @@ int Cdp186x::executeStep()
             }
         }
     }
-    return (_cpu.getCycles() >> 3) % 3668;
+    return {(_cpu.getCycles() >> 3) % 3668, vsync};
 }
 
 void Cdp186x::incrementBackground()

--- a/src/emulation/hardware/cdp186x.hpp
+++ b/src/emulation/hardware/cdp186x.hpp
@@ -30,6 +30,7 @@
 #include <emulation/videoscreen.hpp>
 
 #include <array>
+#include <utility>
 
 namespace emu {
 
@@ -48,7 +49,7 @@ public:
     void reset();
     bool getNEFX() const;
     Type getType() const { return _type; }
-    int executeStep();
+    std::pair<int,bool> executeStep();
     void enableDisplay();
     void disableDisplay();
     bool isDisplayEnabled() const { return _displayEnabled; }

--- a/src/emulation/ichip8.hpp
+++ b/src/emulation/ichip8.hpp
@@ -119,9 +119,10 @@ public:
     virtual void setPalette(std::array<uint32_t,256>& palette) {}
 
     // optional interfaces for audio and/or modern CHIP-8 variant properties
-    virtual float getAudioPhase() const { return 0.0f; }
-    virtual void setAudioPhase(float) { }
-    virtual float getAudioFrequency() const { return 1400.0f; }
+    //virtual float getAudioPhase() const { return 0.0f; }
+    //virtual void setAudioPhase(float) { }
+    //virtual float getAudioFrequency() const { return 1400.0f; }
+    virtual void renderAudio(int16_t* samples, size_t frames, int sampleFrequency) { while (frames--) *samples++ = 0; }
     virtual const uint8_t* getXOAudioPattern() const { return nullptr; }
     virtual uint8_t getXOPitch() const { return 0; }
     virtual uint8_t getNextMCSample() { return 0; }

--- a/src/emulation/octocartridge.cpp
+++ b/src/emulation/octocartridge.cpp
@@ -64,7 +64,7 @@ static Chip8EmulatorOptions optionsFromOctoOptions(const octo_options& octo)
 
 OctoCartridge emu::OctoCartridge::load(std::string filename)
 {
-    auto data = loadFile(filename);
+    auto data = loadFile(filename, 65536);
     octo_options options;
     octo_default_options(&options);
     octo_str source;

--- a/src/emulation/utility.hpp
+++ b/src/emulation/utility.hpp
@@ -101,12 +101,14 @@ inline std::vector<std::string> split(const std::string& s, char delimiter)
     return result;
 }
 
-inline std::vector<uint8_t> loadFile(const std::string& file)
+inline std::vector<uint8_t> loadFile(const std::string& file, size_t maxSize)
 {
     std::ifstream is(file, std::ios::binary | std::ios::ate);
     auto size = is.tellg();
     is.seekg(0, std::ios::beg);
-
+    if(size > maxSize) {
+        return {};
+    }
     std::vector<uint8_t> buffer(size);
     if (is.read((char*)buffer.data(), size)) {
         return buffer;

--- a/src/librarian.cpp
+++ b/src/librarian.cpp
@@ -76,7 +76,7 @@ static KnownRomInfo g_knownRoms[] = {
     //{"044021b046cf207c0b555ea884d61a726f7a3c22", {emu::Chip8EmulatorOptions::eSCHIP11}},
     {"044021b046cf207c0b555ea884d61a726f7a3c22", emu::chip8::Variant::SCHIPC, "Ded-Lok (parityb1t, 2015)", nullptr, nullptr},
     {"048659b97e0cf9506eba85ef7baaf21ada22c6f2", emu::chip8::Variant::CHIP_8, "Astro Dodge (Revival Studios)", nullptr, nullptr},
-    {"04e18ff4ae42e3056c502e0c99d4740ecea65966", emu::chip8::Variant::XO_CHIP, "Nyan Cat (Kouzerumatsu, 2022)", nullptr, nullptr},
+    {"04e18ff4ae42e3056c502e0c99d4740ecea65966", emu::chip8::Variant::XO_CHIP, "Nyan Cat 2 (Kouzerumatsu, 2022)", R"({"instructionsPerFrame": 10000})", nullptr},
     {"050f07a54371da79f924dd0227b89d07b4f2aed0", emu::chip8::Variant::CHIP_8, "Hidden (David Winter, 1996)", nullptr, nullptr},
     {"0572f188fc25ccda14b0c306c4156fe4b1d21ae1", emu::chip8::Variant::GENERIC_CHIP_8, "4-Flags (Timendus, 2023-04-12)", nullptr, "@GH/Timendus/chip8-test-suite/v4.0/bin/4-flags.ch8"},
     {"064492173cf4ccac3cce8fe307fc164b397013b9", emu::chip8::Variant::CHIP_8, "Division Test (Sergey Naydenov, 2010)", nullptr, nullptr},
@@ -520,6 +520,7 @@ static KnownRomInfo g_knownRoms[] = {
     {"a9bf29597674c39b4e11d964b352b1e52c4ebb2f", emu::chip8::Variant::SCHIPC, "Line Demo (unknown aauthor)", nullptr, nullptr},
     {"a9d3c975a5e733646a04f6e61deebcd0ad50f700", emu::chip8::Variant::CHIP_8, "Outlaw (JohnEarnest, 2014-07-17)", R"({"instructionsPerFrame": 15, "optWrapSprites": true, "advanced": {"col0": "#664400", "col1": "#AA4400", "buzzColor": "#FF7F50", "quietColor": "#000000"}})", nullptr},
     {"aa4f1a282bd64a2364102abf5737a4205365a2b4", emu::chip8::Variant::CHIP_8, "Space Flight", nullptr, nullptr},                    // Space Flight.ch8
+    {"aae22735122c1e15df1dde4ef19e7b4968d88f6f", emu::chip8::Variant::XO_CHIP, "Nyan Cat 1 (Kouzerumatsu, 2022)", R"({"instructionsPerFrame": 100000})", nullptr},
     {"ab36ced6e34affacd57b2874ede3f95b669a424c", emu::chip8::Variant::XO_CHIP, "Jub8 Song 1 (your name here, 2016-08-31)", R"({"instructionsPerFrame": 1000, "advanced": {"col1": "#000000", "col2": "#FDFFD5", "col3": "#BA5A1A", "col0": "#353C41", "buzzColor": "#353C41", "quietColor": "#353C41", "screenRotation": 0}})", nullptr},
     {"ab5cbf267d74c168e174041b9594ae856cbd671d", emu::chip8::Variant::CHIP_8, "Chipwar (JohnEarnest, 2014-06-06)", R"({"instructionsPerFrame": 15, "advanced": {"col0": "#6699FF", "col1": "#000066", "buzzColor": "#FFAA00", "quietColor": "#000000"}})", nullptr},
     {"abfce04ddd0f72838dd887f3db3106066fd675b3", emu::chip8::Variant::SCHIP_1_1, "Squad (JohnEarnest, 2020-10-25)", R"({"instructionsPerFrame": 500, "advanced": {"col1": "#FFAF00", "col2": "#FD8100", "col3": "#FD8100", "col0": "#663300", "buzzColor": "#F9FFB3", "quietColor": "#000000", "screenRotation": 0, "fontStyle": "octo"}})", nullptr},

--- a/src/librarian.hpp
+++ b/src/librarian.hpp
@@ -36,6 +36,7 @@
 class Librarian
 {
 public:
+    static constexpr size_t MAX_ROM_SIZE = 16 * 1024 * 1024 - 512;
     struct Info
     {
         enum Type { eDIRECTORY, eUNKNOWN_FILE, eROM_FILE, eOCTO_SOURCE };


### PR DESCRIPTION
This PR changes the way audio rendering is done by moving the actual sample generation into the codes to not bleed variant sound knowledge into the host, also samples are not pushed on vertical blank. Frame boost is disabled by this PR, not only because the current audio rendering doesn't work well with it but also as it is broken by previous changes anyway. It will be tackled on a different work package.